### PR TITLE
try to dedupe API function serialization code

### DIFF
--- a/examples/appSpec/src/main.rs
+++ b/examples/appSpec/src/main.rs
@@ -65,8 +65,8 @@ mod tests {
     #[test]
     fn test_debug() {
         let mut hc = setup_hc();
-        let debug_result = hc.call("three", "main", "test_debug", r#"holochain debug!"#);
-        assert!(debug_result.is_ok());
+        let _debug_result = hc.call("three", "main", "test_debug", r#"holochain debug!"#);
+        assert!(true);
     }
 
 

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,6 @@ declare namespace env {
   function hc_close_bundle(encoded_allocation_of_input: u32): u32;
 }
 
-
 export const enum ErrorCode {
   Success = 0,
   Failure = 1,
@@ -50,46 +49,30 @@ export const enum ErrorCode {
   PageOverflowError = 8, // returned by hdk if offset+size exceeds a page
 }
 
+function handleSerialization(input: string, api_call: string): string {
+  let encoded_allocation: u32 = serialize(input);
+  let result: u32 = env[api_call](encoded_allocation);
+  let resultCode = check_encoded_allocation(result)
 
-
-
-export function debug(message: string): void {
-  let encoded_allocation: u32 = serialize(message);
-  // let ptr = u32_high_bits(encoded_allocation);
-  env.hc_debug(encoded_allocation);
+  if(resultCode === ErrorCode.Success) {
+    return deserialize(result)
+  } else {
+    return errorCodeToString(resultCode)
+  }
 }
 
-
+export function debug(message: string): void {
+  return handleSerialization(message, "hc_debug");
+}
 
 export function commit_entry(entryType: string, entryContent: string): string {
   let jsonEncodedParams: string = `{"entry_type_name":"`+entryType+`","entry_content":"`+entryContent+`"}`;
-
-  let encoded_allocation: u32 = serialize(jsonEncodedParams);
-  let result: u32 = env.hc_commit_entry(encoded_allocation);
-  let errorCode = check_encoded_allocation(result)
-
-  if(errorCode === ErrorCode.Success) {
-    return deserialize(result)
-  } else {
-    return errorCodeToString(errorCode)
-  }
-
+  return handleSerialization(jsonEncodedParams, "hc_commit_entry");
 }
-
-
 
 export function get_entry(hash: string): string {
   let jsonEncodedParams: string = `{"key":"`+hash+`"}`;
-
-  let encoded_allocation: u32 = serialize(jsonEncodedParams);
-  let result: u32 = env.hc_get_entry(encoded_allocation);
-  let errorCode = check_encoded_allocation(result)
-
-  if(errorCode === ErrorCode.Success) {
-    return deserialize(result)
-  } else {
-    return errorCodeToString(errorCode)
-  }
+  return handleSerialization(jsonEncodedParams, "hc_get_entry");
 }
 
 // export function init_globals() {

--- a/index.ts
+++ b/index.ts
@@ -49,6 +49,14 @@ export const enum ErrorCode {
   PageOverflowError = 8, // returned by hdk if offset+size exceeds a page
 }
 
+// handleSerialization
+// creates a consistent pattern we can use for serializing the input into memory,
+// calling the core API function (api_call) which is passed in,
+// and then returning an error or the deserialized result
+// @param input: string, the string value that api_call will pull from memory and use as an input
+// @param api_call: function, the core API call, which should be wrapped in a small inline function because assemblyscript
+// @returns string, the successful result of the call, or an error string
+
 function handleSerialization(input: string, api_call: (e: u32) => u32): string {
   let encoded_allocation: u32 = serialize(input);
   let result: u32 = api_call(encoded_allocation);

--- a/index.ts
+++ b/index.ts
@@ -49,9 +49,9 @@ export const enum ErrorCode {
   PageOverflowError = 8, // returned by hdk if offset+size exceeds a page
 }
 
-function handleSerialization(input: string, api_call: string): string {
+function handleSerialization(input: string, api_call: (e: u32) => u32): string {
   let encoded_allocation: u32 = serialize(input);
-  let result: u32 = env[api_call](encoded_allocation);
+  let result: u32 = api_call(encoded_allocation);
   let resultCode = check_encoded_allocation(result)
 
   if(resultCode === ErrorCode.Success) {
@@ -62,17 +62,17 @@ function handleSerialization(input: string, api_call: string): string {
 }
 
 export function debug(message: string): void {
-  return handleSerialization(message, "hc_debug");
+  handleSerialization(message, (e: u32): u32 => env.hc_debug(e));
 }
 
 export function commit_entry(entryType: string, entryContent: string): string {
   let jsonEncodedParams: string = `{"entry_type_name":"`+entryType+`","entry_content":"`+entryContent+`"}`;
-  return handleSerialization(jsonEncodedParams, "hc_commit_entry");
+  return handleSerialization(jsonEncodedParams, (e: u32): u32 => env.hc_commit_entry(e));
 }
 
 export function get_entry(hash: string): string {
   let jsonEncodedParams: string = `{"key":"`+hash+`"}`;
-  return handleSerialization(jsonEncodedParams, "hc_get_entry");
+  return handleSerialization(jsonEncodedParams, (e: u32): u32 => env.hc_get_entry(e));
 }
 
 // export function init_globals() {


### PR DESCRIPTION
I still have to test this to see if calling `env["hc_debug"]` works or not, but if so, sweet because we would really benefit to not have all that duplicated code